### PR TITLE
Add a section in the README for environment variable setup and adjust the Cargo dependencies to match worker-build to prevent Action failures.

### DIFF
--- a/.github/workflows/push-cloudflare.yaml
+++ b/.github/workflows/push-cloudflare.yaml
@@ -15,9 +15,10 @@ jobs:
         steps:
             - uses: actions/checkout@v4
 
-            # selecting a toolchain either by action or manual `rustup` calls should happen
-            # before the plugin, as the cache uses the current rustc version as its cache key
+            # 安装 Rust
             - run: rustup toolchain install stable --profile minimal
+
+            # 缓存 Cargo
             - name: Cache Cargo registry and build artifacts
               uses: actions/cache@v3
               with:
@@ -29,19 +30,30 @@ jobs:
                   key: cargo-build-cache-${{ github.run_id }}
                   restore-keys: |
                       cargo-build-cache-
+
+            # 添加 wasm 目标
             - run: rustup target add wasm32-unknown-unknown
+
+            # 编译器依赖
             - name: Install lld
               run: sudo apt install -y lld clang gcc llvm
 
+            # 安装 worker-build（版本不变）
             - name: Install worker-build
               run: |
                   if ! command -v worker-build &> /dev/null; then
                     cargo install worker-build
                   fi
 
+            # 强制安装 wasm-bindgen-cli = 0.2.103
+            - name: Install wasm-bindgen-cli 0.2.103
+              run: cargo install -f wasm-bindgen-cli --version 0.2.103
+
+            # 替换 wrangler 配置
             - name: Replace D1_DATABASE_ID in wrangler.toml
               run: sed -i "s/\${D1_DATABASE_ID}/${{ secrets.D1_DATABASE_ID }}/g" wrangler.toml
 
+            # Cloudflare 部署
             - uses: cloudflare/wrangler-action@v3
               id: cf
               env:

--- a/.github/workflows/push-cloudflare.yaml
+++ b/.github/workflows/push-cloudflare.yaml
@@ -45,22 +45,32 @@ jobs:
             - name: Create D1 Database and Capture ID
               id: create_d1
               run: |
-                db_output=$(npx wrangler d1 create --location apac warden-worker)
-                if [ $? -ne 0 ]; then
-                  echo "::error::Failed to create D1 database."
+                response=$(curl -s -w "\n%{http_code}" -X POST "https://api.cloudflare.com/client/v4/accounts/${{ secrets.CLOUDFLARE_ACCOUNT_ID }}/d1/database" \
+                  -H "Authorization: Bearer ${{ secrets.CLOUDFLARE_API_TOKEN }}" \
+                  -H "Content-Type: application/json" \
+                  --data '{
+                    "name": "warden-worker",
+                    "location": "apac"
+                  }')
+
+                http_code=$(echo "$response" | tail -n1)
+                body=$(echo "$response" | sed '$d')
+
+                if [ "$http_code" -ne 200 ]; then
+                  echo "::error::Failed to create D1 database. HTTP status: $http_code"
+                  echo "Response body: $body"
                   exit 1
                 fi
-                db_id=$(echo "$db_output" | grep -oE '\w{8}-\w{4}-\w{4}-\w{4}-\w{12}')
-                if [ -z "$db_id" ]; then
-                  echo "::error::Failed to extract D1 database ID."
-                  echo "Wrangler output: $db_output"
+
+                db_id=$(echo "$body" | jq -r '.result.uuid')
+                if [ -z "$db_id" ] || [ "$db_id" == "null" ]; then
+                  echo "::error::Failed to extract D1 database ID from response."
+                  echo "Response body: $body"
                   exit 1
                 fi
+
                 echo "D1_DATABASE_ID=$db_id" >> $GITHUB_ENV
                 echo "Successfully created D1 database with ID: $db_id"
-              env:
-                  CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-                  CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 
             - name: Replace D1_DATABASE_ID in wrangler.toml
               run: |
@@ -72,22 +82,61 @@ jobs:
                 echo "Successfully replaced D1_DATABASE_ID in wrangler.toml."
 
             - name: Apply D1 Database Schema
-              run: npx wrangler d1 execute warden-worker -y --remote --file sql/schema.sql
-              env:
-                  CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-                  CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+              run: |
+                sql_content=$(cat sql/schema.sql)
+                response=$(curl -s -w "\n%{http_code}" -X POST "https://api.cloudflare.com/client/v4/accounts/${{ secrets.CLOUDFLARE_ACCOUNT_ID }}/d1/database/${{ env.D1_DATABASE_ID }}/query" \
+                  -H "Authorization: Bearer ${{ secrets.CLOUDFLARE_API_TOKEN }}" \
+                  -H "Content-Type: application/json" \
+                  --data-raw "{\"sql\": \"$sql_content\"}")
+
+                http_code=$(echo "$response" | tail -n1)
+                body=$(echo "$response" | sed '$d')
+
+                if [ "$http_code" -ne 200 ]; then
+                  echo "::error::Failed to apply D1 database schema. HTTP status: $http_code"
+                  echo "Response body: $body"
+                  exit 1
+                fi
+
+                echo "Successfully applied D1 database schema."
 
             - name: Create JWT_SECRET
-              run: openssl rand -base64 48 | tr -d '\n' | npx wrangler secret put JWT_SECRET
-              env:
-                  CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-                  CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+              run: |
+                secret_value=$(openssl rand -base64 48 | tr -d '\n')
+                response=$(curl -s -w "\n%{http_code}" -X PUT "https://api.cloudflare.com/client/v4/accounts/${{ secrets.CLOUDFLARE_ACCOUNT_ID }}/workers/scripts/warden-worker/secrets" \
+                  -H "Authorization: Bearer ${{ secrets.CLOUDFLARE_API_TOKEN }}" \
+                  -H "Content-Type: application/json" \
+                  --data-raw "{\"name\": \"JWT_SECRET\", \"text\": \"$secret_value\"}")
+
+                http_code=$(echo "$response" | tail -n1)
+                body=$(echo "$response" | sed '$d')
+
+                if [ "$http_code" -ne 200 ]; then
+                  echo "::error::Failed to create JWT_SECRET. HTTP status: $http_code"
+                  echo "Response body: $body"
+                  exit 1
+                fi
+
+                echo "Successfully created JWT_SECRET."
 
             - name: Create JWT_REFRESH_SECRET
-              run: openssl rand -base64 48 | tr -d '\n' | npx wrangler secret put JWT_REFRESH_SECRET
-              env:
-                  CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-                  CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+              run: |
+                secret_value=$(openssl rand -base64 48 | tr -d '\n')
+                response=$(curl -s -w "\n%{http_code}" -X PUT "https://api.cloudflare.com/client/v4/accounts/${{ secrets.CLOUDFLARE_ACCOUNT_ID }}/workers/scripts/warden-worker/secrets" \
+                  -H "Authorization: Bearer ${{ secrets.CLOUDFLARE_API_TOKEN }}" \
+                  -H "Content-Type: application/json" \
+                  --data-raw "{\"name\": \"JWT_REFRESH_SECRET\", \"text\": \"$secret_value\"}")
+
+                http_code=$(echo "$response" | tail -n1)
+                body=$(echo "$response" | sed '$d')
+
+                if [ "$http_code" -ne 200 ]; then
+                  echo "::error::Failed to create JWT_REFRESH_SECRET. HTTP status: $http_code"
+                  echo "Response body: $body"
+                  exit 1
+                fi
+
+                echo "Successfully created JWT_REFRESH_SECRET."
 
             - uses: cloudflare/wrangler-action@v3
               id: cf

--- a/.github/workflows/push-cloudflare.yaml
+++ b/.github/workflows/push-cloudflare.yaml
@@ -58,6 +58,9 @@ jobs:
                 fi
                 echo "D1_DATABASE_ID=$db_id" >> $GITHUB_ENV
                 echo "Successfully created D1 database with ID: $db_id"
+              env:
+                  CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+                  CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 
             - name: Replace D1_DATABASE_ID in wrangler.toml
               run: |
@@ -70,12 +73,21 @@ jobs:
 
             - name: Apply D1 Database Schema
               run: npx wrangler d1 execute warden-worker -y --remote --file sql/schema.sql
+              env:
+                  CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+                  CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 
             - name: Create JWT_SECRET
               run: openssl rand -base64 48 | tr -d '\n' | npx wrangler secret put JWT_SECRET
+              env:
+                  CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+                  CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 
             - name: Create JWT_REFRESH_SECRET
               run: openssl rand -base64 48 | tr -d '\n' | npx wrangler secret put JWT_REFRESH_SECRET
+              env:
+                  CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+                  CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 
             - uses: cloudflare/wrangler-action@v3
               id: cf

--- a/.github/workflows/push-cloudflare.yaml
+++ b/.github/workflows/push-cloudflare.yaml
@@ -15,10 +15,9 @@ jobs:
         steps:
             - uses: actions/checkout@v4
 
-            # 安装 Rust
+            # selecting a toolchain either by action or manual `rustup` calls should happen
+            # before the plugin, as the cache uses the current rustc version as its cache key
             - run: rustup toolchain install stable --profile minimal
-
-            # 缓存 Cargo
             - name: Cache Cargo registry and build artifacts
               uses: actions/cache@v3
               with:
@@ -30,38 +29,23 @@ jobs:
                   key: cargo-build-cache-${{ github.run_id }}
                   restore-keys: |
                       cargo-build-cache-
-
-            # 添加 wasm 目标
             - run: rustup target add wasm32-unknown-unknown
-
-            # 编译器依赖
             - name: Install lld
               run: sudo apt install -y lld clang gcc llvm
 
-            # 安装 worker-build
             - name: Install worker-build
               run: |
                   if ! command -v worker-build &> /dev/null; then
                     cargo install worker-build
                   fi
 
-            # 强制安装 wasm-bindgen-cli 0.2.103
-            - name: Install wasm-bindgen-cli 0.2.103
-              run: cargo install -f wasm-bindgen-cli --version 0.2.103
-
-            # 替换 wrangler 配置
             - name: Replace D1_DATABASE_ID in wrangler.toml
               run: sed -i "s/\${D1_DATABASE_ID}/${{ secrets.D1_DATABASE_ID }}/g" wrangler.toml
 
-            # 手动执行构建，覆盖内部 wasm-bindgen
-            - name: Manual build (force wasm-bindgen 0.2.103)
-              run: |
-                  export PATH="$HOME/.cargo/bin:$PATH"
-                  worker-build --release
-
-            # 手动执行部署
             - uses: cloudflare/wrangler-action@v3
+              id: cf
+              env:
+                  D1_DATABASE_ID: ${{ secrets.D1_DATABASE_ID }}
               with:
                   apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
                   accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-                  command: publish

--- a/.github/workflows/push-cloudflare.yaml
+++ b/.github/workflows/push-cloudflare.yaml
@@ -1,51 +1,65 @@
 name: Build
 
 on:
-    push:
-        branches: [main, uat, release*]
-    pull_request_target:
-        branches: [main, uat, release*]
-    workflow_dispatch:
+  push:
+    branches: [main, uat, release*]
+  pull_request_target:
+    branches: [main, uat, release*]
+  workflow_dispatch:
 
 jobs:
-    build:
-        name: Run production build
-        runs-on: ubuntu-latest
+  build:
+    name: Run production build
+    runs-on: ubuntu-latest
 
-        steps:
-            - uses: actions/checkout@v4
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
 
-            # selecting a toolchain either by action or manual `rustup` calls should happen
-            # before the plugin, as the cache uses the current rustc version as its cache key
-            - run: rustup toolchain install stable --profile minimal
-            - name: Cache Cargo registry and build artifacts
-              uses: actions/cache@v3
-              with:
-                  path: |
-                      target
-                      ~/.cargo/bin
-                      ~/.cargo/registry
-                      ~/.cargo/git
-                  key: cargo-build-cache-${{ github.run_id }}
-                  restore-keys: |
-                      cargo-build-cache-
-            - run: rustup target add wasm32-unknown-unknown
-            - name: Install lld
-              run: sudo apt install -y lld clang gcc llvm
+      # 固定 Rust 版本，而不是默认 stable 滚动升级
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install 1.75.0 --profile minimal
+          rustup default 1.75.0
 
-            - name: Install worker-build
-              run: |
-                  if ! command -v worker-build &> /dev/null; then
-                    cargo install worker-build
-                  fi
+      # 固定 cache action 版本
+      - name: Cache Cargo registry and build artifacts
+        uses: actions/cache@v3
+        with:
+          path: |
+            target
+            ~/.cargo/bin
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: cargo-build-cache-${{ github.run_id }}
+          restore-keys: |
+            cargo-build-cache-
 
-            - name: Replace D1_DATABASE_ID in wrangler.toml
-              run: sed -i "s/\${D1_DATABASE_ID}/${{ secrets.D1_DATABASE_ID }}/g" wrangler.toml
+      # 固定 wasm target
+      - name: Add wasm target
+        run: rustup target add wasm32-unknown-unknown
 
-            - uses: cloudflare/wrangler-action@v3
-              id: cf
-              env:
-                  D1_DATABASE_ID: ${{ secrets.D1_DATABASE_ID }}
-              with:
-                  apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-                  accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      # 固定编译工具链版本
+      - name: Install lld
+        run: sudo apt-get update && sudo apt-get install -y lld=1:14.0-55~ubuntu1 clang gcc llvm
+
+      # 固定 worker-build 版本，不使用最新
+      - name: Install worker-build
+        run: |
+          if ! command -v worker-build &> /dev/null; then
+            cargo install worker-build --version 0.3.0
+          fi
+
+      # 替换配置
+      - name: Replace D1_DATABASE_ID in wrangler.toml
+        run: sed -i "s/\${D1_DATABASE_ID}/${{ secrets.D1_DATABASE_ID }}/g" wrangler.toml
+
+      # 固定 wrangler-action 到确定版本
+      - name: Publish to Cloudflare
+        uses: cloudflare/wrangler-action@v3.19.0
+        id: cf
+        env:
+          D1_DATABASE_ID: ${{ secrets.D1_DATABASE_ID }}
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/push-cloudflare.yaml
+++ b/.github/workflows/push-cloudflare.yaml
@@ -18,17 +18,17 @@ jobs:
             # selecting a toolchain either by action or manual `rustup` calls should happen
             # before the plugin, as the cache uses the current rustc version as its cache key
             - run: rustup toolchain install stable --profile minimal
-            - name: Cache Cargo registry and build artifacts
-              uses: actions/cache@v3
-              with:
-                  path: |
-                      target
-                      ~/.cargo/bin
-                      ~/.cargo/registry
-                      ~/.cargo/git
-                  key: cargo-build-cache-${{ github.run_id }}
-                  restore-keys: |
-                      cargo-build-cache-
+            # - name: Cache Cargo registry and build artifacts
+            #   uses: actions/cache@v3
+            #   with:
+            #       path: |
+            #           target
+            #           ~/.cargo/bin
+            #           ~/.cargo/registry
+            #           ~/.cargo/git
+            #       key: cargo-build-cache-${{ github.run_id }}
+            #       restore-keys: |
+            #           cargo-build-cache-
             - run: rustup target add wasm32-unknown-unknown
             - name: Install lld
               run: sudo apt install -y lld clang gcc llvm

--- a/.github/workflows/push-cloudflare.yaml
+++ b/.github/workflows/push-cloudflare.yaml
@@ -38,14 +38,14 @@ jobs:
             - name: Install lld
               run: sudo apt install -y lld clang gcc llvm
 
-            # 安装 worker-build（版本不变）
+            # 安装 worker-build
             - name: Install worker-build
               run: |
                   if ! command -v worker-build &> /dev/null; then
                     cargo install worker-build
                   fi
 
-            # 强制安装 wasm-bindgen-cli = 0.2.103
+            # 强制安装 wasm-bindgen-cli 0.2.103
             - name: Install wasm-bindgen-cli 0.2.103
               run: cargo install -f wasm-bindgen-cli --version 0.2.103
 
@@ -53,11 +53,15 @@ jobs:
             - name: Replace D1_DATABASE_ID in wrangler.toml
               run: sed -i "s/\${D1_DATABASE_ID}/${{ secrets.D1_DATABASE_ID }}/g" wrangler.toml
 
-            # Cloudflare 部署
+            # 手动执行构建，覆盖内部 wasm-bindgen
+            - name: Manual build (force wasm-bindgen 0.2.103)
+              run: |
+                  export PATH="$HOME/.cargo/bin:$PATH"
+                  worker-build --release
+
+            # 手动执行部署
             - uses: cloudflare/wrangler-action@v3
-              id: cf
-              env:
-                  D1_DATABASE_ID: ${{ secrets.D1_DATABASE_ID }}
               with:
                   apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
                   accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+                  command: publish

--- a/.github/workflows/push-cloudflare.yaml
+++ b/.github/workflows/push-cloudflare.yaml
@@ -1,65 +1,51 @@
 name: Build
 
 on:
-  push:
-    branches: [main, uat, release*]
-  pull_request_target:
-    branches: [main, uat, release*]
-  workflow_dispatch:
+    push:
+        branches: [main, uat, release*]
+    pull_request_target:
+        branches: [main, uat, release*]
+    workflow_dispatch:
 
 jobs:
-  build:
-    name: Run production build
-    runs-on: ubuntu-latest
+    build:
+        name: Run production build
+        runs-on: ubuntu-latest
 
-    steps:
-      - name: Checkout source
-        uses: actions/checkout@v4
+        steps:
+            - uses: actions/checkout@v4
 
-      # 固定 Rust 版本，而不是默认 stable 滚动升级
-      - name: Install Rust toolchain
-        run: |
-          rustup toolchain install 1.75.0 --profile minimal
-          rustup default 1.75.0
+            # selecting a toolchain either by action or manual `rustup` calls should happen
+            # before the plugin, as the cache uses the current rustc version as its cache key
+            - run: rustup toolchain install stable --profile minimal
+            - name: Cache Cargo registry and build artifacts
+              uses: actions/cache@v3
+              with:
+                  path: |
+                      target
+                      ~/.cargo/bin
+                      ~/.cargo/registry
+                      ~/.cargo/git
+                  key: cargo-build-cache-${{ github.run_id }}
+                  restore-keys: |
+                      cargo-build-cache-
+            - run: rustup target add wasm32-unknown-unknown
+            - name: Install lld
+              run: sudo apt install -y lld clang gcc llvm
 
-      # 固定 cache action 版本
-      - name: Cache Cargo registry and build artifacts
-        uses: actions/cache@v3
-        with:
-          path: |
-            target
-            ~/.cargo/bin
-            ~/.cargo/registry
-            ~/.cargo/git
-          key: cargo-build-cache-${{ github.run_id }}
-          restore-keys: |
-            cargo-build-cache-
+            - name: Install worker-build
+              run: |
+                  if ! command -v worker-build &> /dev/null; then
+                    cargo install worker-build
+                  fi
 
-      # 固定 wasm target
-      - name: Add wasm target
-        run: rustup target add wasm32-unknown-unknown
+            - name: Replace D1_DATABASE_ID in wrangler.toml
+              run: sed -i "s/\${D1_DATABASE_ID}/${{ secrets.D1_DATABASE_ID }}/g" wrangler.toml
 
-      # 固定编译工具链版本
-      - name: Install lld
-        run: sudo apt-get update && sudo apt-get install -y lld=1:14.0-55~ubuntu1 clang gcc llvm
-
-      # 固定 worker-build 版本，不使用最新
-      - name: Install worker-build
-        run: |
-          if ! command -v worker-build &> /dev/null; then
-            cargo install worker-build --version 0.3.0
-          fi
-
-      # 替换配置
-      - name: Replace D1_DATABASE_ID in wrangler.toml
-        run: sed -i "s/\${D1_DATABASE_ID}/${{ secrets.D1_DATABASE_ID }}/g" wrangler.toml
-
-      # 固定 wrangler-action 到确定版本
-      - name: Publish to Cloudflare
-        uses: cloudflare/wrangler-action@v3
-        id: cf
-        env:
-          D1_DATABASE_ID: ${{ secrets.D1_DATABASE_ID }}
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+            - uses: cloudflare/wrangler-action@v3
+              id: cf
+              env:
+                  D1_DATABASE_ID: ${{ secrets.D1_DATABASE_ID }}
+              with:
+                  apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+                  accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/push-cloudflare.yaml
+++ b/.github/workflows/push-cloudflare.yaml
@@ -56,7 +56,7 @@ jobs:
 
       # 固定 wrangler-action 到确定版本
       - name: Publish to Cloudflare
-        uses: cloudflare/wrangler-action@v3.19.0
+        uses: cloudflare/wrangler-action@v3
         id: cf
         env:
           D1_DATABASE_ID: ${{ secrets.D1_DATABASE_ID }}

--- a/.github/workflows/push-cloudflare.yaml
+++ b/.github/workflows/push-cloudflare.yaml
@@ -39,13 +39,22 @@ jobs:
                     cargo install worker-build
                   fi
 
-            - name: Replace D1_DATABASE_ID in wrangler.toml
-              run: sed -i "s/\${D1_DATABASE_ID}/${{ secrets.D1_DATABASE_ID }}/g" wrangler.toml
+            # - name: Replace D1_DATABASE_ID in wrangler.toml
+            #   run: sed -i "s/\${D1_DATABASE_ID}/${{ secrets.D1_DATABASE_ID }}/g" wrangler.toml
 
             - uses: cloudflare/wrangler-action@v3
               id: cf
-              env:
-                  D1_DATABASE_ID: ${{ secrets.D1_DATABASE_ID }}
+              # env:
+              #     D1_DATABASE_ID: ${{ secrets.D1_DATABASE_ID }}
               with:
+                  preCommands: |
+                      sed -i "s/\${D1_DATABASE_ID}/$(npx wrangler d1 create --location apac warden-worker | grep -oE '\w{8}-\w{4}-\w{4}-\w{4}-\w{12}')/g" wrangler.toml
+                      npx wrangler d1 execute warden-worker -y --remote --file sql/schema.sql
+                      openssl rand -base64 48 | tr -d '\n' | npx wrangler secret put JWT_SECRET
+                      openssl rand -base64 48 | tr -d '\n' | npx wrangler secret put JWT_REFRESH_SECRET
+                  secrets: |
+                      ALLOWED_EMAILS
                   apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
                   accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+              env:
+                  ALLOWED_EMAILS: ${{ secrets.ALLOWED_EMAILS }}

--- a/.github/workflows/push-cloudflare.yaml
+++ b/.github/workflows/push-cloudflare.yaml
@@ -42,16 +42,44 @@ jobs:
             # - name: Replace D1_DATABASE_ID in wrangler.toml
             #   run: sed -i "s/\${D1_DATABASE_ID}/${{ secrets.D1_DATABASE_ID }}/g" wrangler.toml
 
+            - name: Create D1 Database and Capture ID
+              id: create_d1
+              run: |
+                db_output=$(npx wrangler d1 create --location apac warden-worker)
+                if [ $? -ne 0 ]; then
+                  echo "::error::Failed to create D1 database."
+                  exit 1
+                fi
+                db_id=$(echo "$db_output" | grep -oE '\w{8}-\w{4}-\w{4}-\w{4}-\w{12}')
+                if [ -z "$db_id" ]; then
+                  echo "::error::Failed to extract D1 database ID."
+                  echo "Wrangler output: $db_output"
+                  exit 1
+                fi
+                echo "D1_DATABASE_ID=$db_id" >> $GITHUB_ENV
+                echo "Successfully created D1 database with ID: $db_id"
+
+            - name: Replace D1_DATABASE_ID in wrangler.toml
+              run: |
+                if [ -z "${{ env.D1_DATABASE_ID }}" ]; then
+                  echo "::error::D1_DATABASE_ID is not set."
+                  exit 1
+                fi
+                sed -i "s/\${D1_DATABASE_ID}/${{ env.D1_DATABASE_ID }}/g" wrangler.toml
+                echo "Successfully replaced D1_DATABASE_ID in wrangler.toml."
+
+            - name: Apply D1 Database Schema
+              run: npx wrangler d1 execute warden-worker -y --remote --file sql/schema.sql
+
+            - name: Create JWT_SECRET
+              run: openssl rand -base64 48 | tr -d '\n' | npx wrangler secret put JWT_SECRET
+
+            - name: Create JWT_REFRESH_SECRET
+              run: openssl rand -base64 48 | tr -d '\n' | npx wrangler secret put JWT_REFRESH_SECRET
+
             - uses: cloudflare/wrangler-action@v3
               id: cf
-              # env:
-              #     D1_DATABASE_ID: ${{ secrets.D1_DATABASE_ID }}
               with:
-                  preCommands: |
-                      sed -i "s/\${D1_DATABASE_ID}/$(npx wrangler d1 create --location apac warden-worker | grep -oE '\w{8}-\w{4}-\w{4}-\w{4}-\w{12}')/g" wrangler.toml
-                      npx wrangler d1 execute warden-worker -y --remote --file sql/schema.sql
-                      openssl rand -base64 48 | tr -d '\n' | npx wrangler secret put JWT_SECRET
-                      openssl rand -base64 48 | tr -d '\n' | npx wrangler secret put JWT_REFRESH_SECRET
                   secrets: |
                       ALLOWED_EMAILS
                   apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -536,9 +536,9 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "js-sys"
-version = "0.3.80"
+version = "0.3.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "852f13bec5eba4ba9afbeb93fd7c13fe56147f055939ae21c43a29a0ecb2702e"
+checksum = "b011eec8cc36da2aab2d5cff675ec18454fad408585853910a202391cf9f8e65"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -1215,7 +1215,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "worker",
- "worker-macros",
+ "worker-macros 0.6.5",
 ]
 
 [[package]]
@@ -1244,9 +1244,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.103"
+version = "0.2.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab10a69fbd0a177f5f649ad4d8d3305499c42bab9aef2f7ff592d0ec8f833819"
+checksum = "da95793dfc411fbbd93f5be7715b0578ec61fe87cb1a42b12eb625caa5c5ea60"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1256,24 +1256,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.103"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bb702423545a6007bbc368fde243ba47ca275e549c8a28617f56f6ba53b1d1c"
-dependencies = [
- "bumpalo",
- "log",
- "proc-macro2",
- "quote",
- "syn",
- "wasm-bindgen-shared",
-]
-
-[[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.53"
+version = "0.4.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0b221ff421256839509adbb55998214a70d829d3a28c69b4a6672e9d2a42f67"
+checksum = "551f88106c6d5e7ccc7cd9a16f312dd3b5d36ea8b4954304657d5dfba115d4a0"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -1284,9 +1270,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.103"
+version = "0.2.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc65f4f411d91494355917b605e1480033152658d71f722a90647f56a70c88a0"
+checksum = "04264334509e04a7bf8690f2384ef5265f05143a4bff3889ab7a3269adab59c2"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1294,22 +1280,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.103"
+version = "0.2.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffc003a991398a8ee604a401e194b6b3a39677b3173d6e74495eb51b82e99a32"
+checksum = "420bc339d9f322e562942d52e115d57e950d12d88983a14c79b86859ee6c7ebc"
 dependencies = [
+ "bumpalo",
  "proc-macro2",
  "quote",
  "syn",
- "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.103"
+version = "0.2.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "293c37f4efa430ca14db3721dfbe48d8c33308096bd44d80ebaa775ab71ba1cf"
+checksum = "76f218a38c84bcb33c25ec7059b07847d465ce0e0a76b995e134a45adcb6af76"
 dependencies = [
  "unicode-ident",
 ]
@@ -1329,9 +1315,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.80"
+version = "0.3.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbe734895e869dc429d78c4b433f8d17d95f8d05317440b4fad5ab2d33e596dc"
+checksum = "3a1f95c0d03a47f4ae1f7a64643a6bb97465d9b740f0fa8f90ea33915c99a9a1"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -1486,9 +1472,9 @@ checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
 name = "worker"
-version = "0.6.5"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38079fb888798411da925f8e7da31d05f99f34d960876e7f0f64d38dd1c5a8e4"
+checksum = "c297e1a9f0e31ca0ba7e655977412bd85771278dafe5b84fc46f72b5caef5b6d"
 dependencies = [
  "async-trait",
  "axum",
@@ -1511,24 +1497,8 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "worker-kv",
- "worker-macros",
- "worker-sys",
-]
-
-[[package]]
-name = "worker-kv"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0d30eb90e8db0657414129624c0d12c6cb480574bc2ddd584822db196cb9a52"
-dependencies = [
- "js-sys",
- "serde",
- "serde-wasm-bindgen",
- "serde_json",
- "thiserror 2.0.16",
- "wasm-bindgen",
- "wasm-bindgen-futures",
+ "worker-macros 0.7.0",
+ "worker-sys 0.7.0",
 ]
 
 [[package]]
@@ -1544,7 +1514,23 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-bindgen-macro-support",
- "worker-sys",
+ "worker-sys 0.6.5",
+]
+
+[[package]]
+name = "worker-macros"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6d57d9439ad92355f1e561bbbb33abf403125850c9b25ea6be4371b8bebcd4e"
+dependencies = [
+ "async-trait",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-bindgen-macro-support",
+ "worker-sys 0.7.0",
 ]
 
 [[package]]
@@ -1552,6 +1538,18 @@ name = "worker-sys"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa601b8e81a1a06f0b0cc1ca5d48eef4901f491d324a4b2796354b0d49aeeaf0"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "worker-sys"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5abe9e356c630837d9dd7ee465946f809368b110672fdf1334ff64f89290981"
 dependencies = [
  "cfg-if",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ codegen-units = 1
 
 [dependencies]
 # Worker & Web APIs
-worker = { version = "0.6", features = ["axum", "http", "d1"] }
+worker = { version = "0.7.0", features = ["axum", "http", "d1"] }
 worker-macros = { version = "0.6", features = ['http'] }
 wasm-bindgen = "0.2.105"
 js-sys = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ codegen-units = 1
 # Worker & Web APIs
 worker = { version = "0.6", features = ["axum", "http", "d1"] }
 worker-macros = { version = "0.6", features = ['http'] }
-wasm-bindgen = "0.2"
+wasm-bindgen = "0.2.103"
 js-sys = "0.3"
 wasm-bindgen-futures = "0.4"
 web-sys = { version = "0.3", features = ["Crypto", "CryptoKey", "SubtleCrypto", "WorkerGlobalScope", "Pbkdf2Params"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ codegen-units = 1
 # Worker & Web APIs
 worker = { version = "0.6", features = ["axum", "http", "d1"] }
 worker-macros = { version = "0.6", features = ['http'] }
-wasm-bindgen = "0.2.103"
+wasm-bindgen = "0.2.105"
 js-sys = "0.3"
 wasm-bindgen-futures = "0.4"
 web-sys = { version = "0.3", features = ["Crypto", "CryptoKey", "SubtleCrypto", "WorkerGlobalScope", "Pbkdf2Params"] }

--- a/README.md
+++ b/README.md
@@ -1,113 +1,140 @@
-# Warden: A Bitwarden-compatible server for Cloudflare Workers
+明白了！我将简要地描述如何使用仓库中已经存在的 GitHub Actions 工作流。以下是更新后的 README 内容：
 
-This project provides a self-hosted, Bitwarden-compatible server that can be deployed to Cloudflare Workers for free. It's designed to be low-maintenance, allowing you to "deploy and forget" without worrying about server management or recurring costs.
+---
 
-## Why another Bitwarden server?
+## Warden: 适用于 Cloudflare Workers 的 Bitwarden 兼容服务器
 
-While projects like [Vaultwarden](https://github.com/dani-garcia/vaultwarden) provide excellent self-hosted solutions, they still require you to manage a server or VPS. This can be a hassle, and if you forget to pay for your server, you could lose access to your passwords.
+该项目提供了一个自托管的 Bitwarden 兼容服务器，可以免费部署到 Cloudflare Workers。它设计为低维护性，允许你“一次部署，忘掉它”，无需担心服务器管理或重复费用。
 
-Warden aims to solve this problem by leveraging the Cloudflare Workers ecosystem. By deploying Warden to a Cloudflare Worker and using Cloudflare D1 for storage, you can have a completely free, serverless, and low-maintenance Bitwarden server.
+### 为什么要另建一个 Bitwarden 服务器？
 
-## Features
+虽然像 [Vaultwarden](https://github.com/dani-garcia/vaultwarden) 这样的项目提供了出色的自托管解决方案，但它们仍然需要你管理服务器或 VPS。这可能比较麻烦，如果忘记支付服务器费用，你可能会失去对密码的访问。
 
-*   **Core Vault Functionality:** All your basic vault operations are supported, including creating, reading, updating, and deleting ciphers and folders.
-*   **TOTP Support:** Store and generate Time-based One-Time Passwords for your accounts.
-*   **Bitwarden Compatible:** Works with the official Bitwarden browser extensions and Android app (iOS is untested).
-*   **Free to Host:** Runs on Cloudflare's free tier.
-*   **Low Maintenance:** Deploy it once and forget about it.
-*   **Secure:** Your data is stored in your own Cloudflare D1 database.
-*   **Easy to Deploy:** Get up and running in minutes with the Wrangler CLI.
+Warden 旨在通过利用 Cloudflare Workers 生态系统来解决这个问题。通过将 Warden 部署到 Cloudflare Worker 并使用 Cloudflare D1 存储，你可以拥有一个完全免费的、无服务器的、低维护的 Bitwarden 服务器。
 
-## Current Status
+### 功能特点
 
-**This project is not yet feature-complete.** It currently supports the core functionality of a personal vault, including TOTP. However, it does **not** support the following features:
+* **核心保管库功能：** 支持所有基本的保管库操作，包括创建、读取、更新和删除密码和文件夹。
+* **TOTP 支持：** 为你的账户存储和生成基于时间的一次性密码。
+* **Bitwarden 兼容：** 支持官方 Bitwarden 浏览器扩展和 Android 应用（iOS 未经过测试）。
+* **免费托管：** 运行在 Cloudflare 的免费层上。
+* **低维护：** 一次部署，之后无需担心。
+* **安全：** 你的数据存储在你自己的 Cloudflare D1 数据库中。
+* **易于部署：** 使用 Wrangler CLI 快速上手，几分钟内即可完成部署。
 
-*   Sharing
-*   Bitwarden Send
-*   Organizations
-*   Other Bitwarden advanced features
+### 当前状态
 
-There are no immediate plans to implement these features. The primary goal of this project is to provide a simple, free, and low-maintenance personal password manager.
+**该项目尚未完成所有功能。** 目前支持个人保管库的核心功能，包括 TOTP。然而，它并不支持以下功能：
 
-## Compatibility
+* 分享功能
+* Bitwarden 发送功能
+* 组织功能
+* 其他 Bitwarden 高级功能
 
-*   **Browser Extensions:** Chrome, Firefox, Safari, etc.
-*   **Android App:** The official Bitwarden Android app.
-*   **iOS App:** Untested. If you have an iOS device, please test and report your findings!
+这些功能目前没有计划实现。该项目的主要目标是提供一个简单、免费的低维护个人密码管理器。
 
-## Getting Started
+### 兼容性
 
-### Prerequisites
+* **浏览器扩展：** Chrome、Firefox、Safari 等。
+* **Android 应用：** 官方 Bitwarden Android 应用。
+* **iOS 应用：** 未经过测试。如果你有 iOS 设备，请测试并反馈你的结果！
 
-*   A Cloudflare account.
-*   The [Wrangler CLI](https://developers.cloudflare.com/workers/wrangler/get-started/) installed and configured.
+### 快速开始
 
-### Deployment
+#### 前提条件
 
-1.  **Clone the repository:**
+* 一个 Cloudflare 账户。
+* 已安装并配置好的 [Wrangler CLI](https://developers.cloudflare.com/workers/wrangler/get-started/)。
 
-    ```bash
-    git clone https://github.com/your-username/warden-worker.git
-    cd warden-worker
-    ```
+#### 部署步骤
 
-2.  **Create a D1 Database:**
+1. **克隆仓库：**
 
-    ```bash
-    wrangler d1 create warden-db
-    ```
+   ```bash
+   git clone https://github.com/your-username/warden-worker.git
+   cd warden-worker
+   ```
 
-3.  **Configure your Database ID:**
+2. **创建 D1 数据库：**
 
-    When you create a D1 database, Wrangler will output the `database_id`. To avoid committing this secret to your repository, this project uses an environment variable to configure the database ID.
+   ```bash
+   wrangler d1 create warden-db
+   ```
 
-    You have two options:
+3. **配置数据库 ID：**
 
-    **Option 1: (Recommended) Use a `.env` file:**
+   创建 D1 数据库时，Wrangler 会输出 `database_id`。为了避免将此秘密提交到你的代码仓库，本项目使用环境变量来配置数据库 ID。
 
-    Create a file named `.env` in the root of the project and add the following line, replacing the placeholder with your actual `database_id`:
+   你有两个选项：
 
-    ```
-    D1_DATABASE_ID="your-database-id-goes-here"
-    ```
+   **选项 1：（推荐）使用 `.env` 文件：**
 
-    Make sure to add the `.env` file to your `.gitignore` file to prevent it from being committed to git.
+   在项目根目录下创建一个名为 `.env` 的文件，并添加以下行，将占位符替换为实际的 `database_id`：
 
-    **Option 2: Set an environment variable in your shell:**
+   ```
+   D1_DATABASE_ID="your-database-id-goes-here"
+   ```
 
-    You can set the environment variable in your shell before deploying:
+   确保将 `.env` 文件添加到 `.gitignore` 文件中，以防止其被提交到 Git。
 
-    ```bash
-    export D1_DATABASE_ID="your-database-id-goes-here"
-    wrangler deploy
-    ```
+   **选项 2：在你的 shell 中设置环境变量：**
 
-4.  **Deploy the worker:**
+   在部署之前，可以在 shell 中设置环境变量：
 
-    ```bash
-    wrangler deploy
-    ```
+   ```bash
+   export D1_DATABASE_ID="your-database-id-goes-here"
+   wrangler deploy
+   ```
 
-    This will deploy the worker and set up the necessary database tables.
+4. **部署 Worker：**
 
-5. **Set environment variables**
-   
-- `ALLOWED_EMAILS` your-email@example.com
-- `JWT_SECRET` a long random string
-- `JWT_REFRESH_SECRET` a long random string
+   ```bash
+   wrangler deploy
+   ```
 
-6.  **Configure your Bitwarden client:**
+   这将部署 Worker 并设置必要的数据库表。
 
-    In your Bitwarden client, go to the self-hosted login screen and enter the URL of your deployed worker (e.g., `https://warden-worker.your-username.workers.dev`).
+5. **设置环境变量：**
 
-## Configuration
+* `ALLOWED_EMAILS` 你的邮箱（例如：`your-email@example.com`）
+* `JWT_SECRET` 一串长随机字符串
+* `JWT_REFRESH_SECRET` 一串长随机字符串
 
-This project requires minimal configuration. The main configuration is done in the `wrangler.toml` file, where you specify your D1 database binding.
+6. **配置 Bitwarden 客户端：**
 
-## Contributing
+   在你的 Bitwarden 客户端中，访问自托管登录页面并输入你部署的 Worker URL（例如：`https://warden-worker.your-username.workers.dev`）。
 
-Contributions are welcome! If you find a bug, have a feature request, or want to improve the code, please open an issue or submit a pull request.
+### 使用 GitHub Actions 自动化部署
 
-## License
+在项目中，已经预设了一个 GitHub Actions 工作流来自动化构建和部署过程。你可以直接使用它来为你的项目实现持续集成和部署。
 
-This project is licensed under the MIT License. See the `LICENSE` file for details.
+#### 如何使用现有的工作流？
+
+1. 确保你的 GitHub 仓库已经包含了必要的 Secrets 配置：
+
+   * `CLOUDFLARE_API_TOKEN`: 用于认证 Cloudflare API 的令牌。
+   * `CLOUDFLARE_ACCOUNT_ID`: 你的 Cloudflare 账户 ID。
+   * `ALLOWED_EMAILS`: 允许的电子邮件地址。
+   * `JWT_SECRET` 和 `JWT_REFRESH_SECRET`: 用于保护 JWT 身份验证的密钥。
+
+2. 当你将更改推送到 `main`、`uat` 或 `release*` 分支时，工作流会自动触发并执行构建与部署过程。
+
+3. 如果你想手动触发工作流，可以通过 GitHub Actions 页面中的 "Run workflow" 按钮来执行。
+
+4. 你也可以根据需要修改工作流文件（位于 `.github/workflows/` 文件夹内），例如更改部署的 Cloudflare Worker 配置或构建步骤。
+
+### 配置
+
+该项目需要最少的配置。主要配置是在 `wrangler.toml` 文件中进行的，在那里你需要指定你的 D1 数据库绑定。
+
+### 贡献
+
+欢迎贡献！如果你发现 bug，想提出功能请求或改进代码，请提交 issue 或 pull request。
+
+### 许可证
+
+该项目遵循 MIT 许可证。详情请参阅 `LICENSE` 文件。
+
+---
+
+通过这样的说明，新手可以快速了解如何使用已有的 GitHub Actions 工作流进行自动化部署，而不需要手动配置复杂的 CI/CD 管道。

--- a/README.md
+++ b/README.md
@@ -90,7 +90,13 @@ There are no immediate plans to implement these features. The primary goal of th
 
     This will deploy the worker and set up the necessary database tables.
 
-5.  **Configure your Bitwarden client:**
+5. **Set environment variables**
+   
+- `ALLOWED_EMAILS` your-email@example.com
+- `JWT_SECRET` a long random string
+- `JWT_REFRESH_SECRET` a long random string
+
+6.  **Configure your Bitwarden client:**
 
     In your Bitwarden client, go to the self-hosted login screen and enter the URL of your deployed worker (e.g., `https://warden-worker.your-username.workers.dev`).
 


### PR DESCRIPTION
I made two changes:

1. Declared the environment variable configuration in the README. I have tested this, and these variables are required; otherwise, the project will not work.
2. Updated the version of `wasm-bindgen` in `Cargo.toml` to prevent GitHub Actions from throwing the following error:

```
error: 

it looks like the Rust project used to create this Wasm file was linked against
version of wasm-bindgen that uses a different bindgen format than this binary:

 rust Wasm file schema version: 0.2.103
     this binary schema version: 0.2.105 (f72a9d68d)

Currently the bindgen format is unstable enough that these two schema versions
must exactly match. You can accomplish this by either updating this binary or
the wasm-bindgen dependency in the Rust project.

You should be able to update the wasm-bindgen dependency with:

    cargo update -p wasm-bindgen --precise 0.2.105 (f72a9d68d)

don't forget to recompile your Wasm file! Alternatively, you can update the
binary with:

    cargo install -f wasm-bindgen-cli --version 0.2.103

if this warning fails to go away though and you're not sure what to do feel free
to open an issue at https://github.com/wasm-bindgen/wasm-bindgen/issues!

Error: Running the wasm-bindgen CLI

Caused by:
    failed to execute `wasm-bindgen`: exited with exit status: 1
      full command: "/home/runner/.cache/worker-build/wasm-bindgen-x86_64-unknown-linux-musl-0.2.105/wasm-bindgen" "/home/runner/work/warden-worker/warden-worker/target/wasm32-unknown-unknown/release/warden_worker.wasm" "--out-dir" "/home/runner/work/warden-worker/warden-worker/build" "--typescript" "--target" "module" "--out-name" "index" "--experimental-reset-state-function"
```
